### PR TITLE
CPP17 Feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ CTestTestfile.cmake
 _deps
 
 # build folder
+linux_build
 build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,17 @@ set( VERSION 1.0.0 )
 
 project( "ZTech" VERSION ${VERSION} )
 option(ENABLE_TESTS "Enable tests" OFF)
+option(USING_CPP17 "Use C++17 features" ON)
+set(ZTECH_ECS_LIBRARIES pthread)
 
-set(CMAKE_CXX_STANDARD 17)
+if( USING_CPP17 )
+    set(CMAKE_CXX_STANDARD 17)
+    set(ZTECH_ECS_LIBRARIES pthread tbb)
+    add_definitions( -DUSING_CPP17=1 )
+else()
+    set(CMAKE_CXX_STANDARD 17)
+    add_definitions( -DUSING_CPP17=0 )
+endif()
 
 file( GLOB_RECURSE SRC "${CMAKE_CURRENT_SOURCE_DIR}/private/*.cpp" )
 
@@ -13,24 +22,31 @@ include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/public
 )
 
-add_library( "ztech.ecs" STATIC "${SRC}" )
-#add_executable( "ecstest" "${SRC}" )
+add_library( "ztech.ecs" STATIC "${SRC}" ) 
+target_link_libraries( "ztech.ecs" "${ZTECH_ECS_LIBRARIES}" )
 
+#add_executable( "ecstest" "${SRC}" )
+# -pthread -ltbb
 if( ENABLE_TESTS )
     enable_testing( )
     MESSAGE( "Adding UnitTests" )
     add_executable( "ecstest" "unit_test/main.cpp" "${SRC}" )
+    target_link_libraries( "ecstest" "${ZTECH_ECS_LIBRARIES}" )
     add_test( "UnitTest" "ecstest" )
 
     add_executable( "ecsreg" "unit_test/check_component_registration.cpp" "${SRC}" )
+    target_link_libraries( "ecsreg" "${ZTECH_ECS_LIBRARIES}" )
     add_test( "EcsReg" "ecsreg" )
 
     add_executable( "ecsallocone" "unit_test/check_entity_one_alloc.cpp" "${SRC}" )
+    target_link_libraries( "ecsallocone" "${ZTECH_ECS_LIBRARIES}" )
     add_test( "EcsAllocOne" "ecsallocone" )
 
     add_executable( "ecssysreg" "unit_test/check_system_def.cpp" "${SRC}" )
+    target_link_libraries( "ecssysreg" "${ZTECH_ECS_LIBRARIES}" )
     add_test( "EcsSysReg" "ecssysreg" )
 
     add_executable( "ecscomposer" "unit_test/check_composer.cpp" "${SRC}" )
+    target_link_libraries( "ecscomposer" "${ZTECH_ECS_LIBRARIES}" )
     add_test( "EcsComposer" "ecscomposer" )
 endif( )

--- a/unit_test/check_composer.cpp
+++ b/unit_test/check_composer.cpp
@@ -11,7 +11,7 @@ constexpr size_t entity_count = 100;
 static ztech::ecs::composer global_composer;
 static std::shared_ptr< ztech::ecs::entity_array > car_entities;
 static std::shared_ptr< ztech::ecs::system > car_system;
-static std::atomic< int > system_excution_count = 0;
+static std::atomic< size_t > system_excution_count = 0;
 
 
 void move_car( std::shared_ptr< ztech::ecs::entity_array > arr, ztech::ecs::entity_id_t id, float deltaSeconds )
@@ -120,7 +120,7 @@ int main( int argc, char* argv[] )
 
     {
         printf( "Count with ForEach\n" );
-        int count = 0;
+        size_t count = 0;
         car_entities->for_each( [&count]( ztech::ecs::entity_id_t id )
         {
             count++;
@@ -135,8 +135,8 @@ int main( int argc, char* argv[] )
 
     {
         printf( "Count with Template ForEach\n" );
-        int count = 0;
-        car_entities->for_each< int* >( []( int* count, ztech::ecs::entity_id_t id )
+        size_t count = 0;
+        car_entities->for_each< size_t* >( []( ztech::ecs::entity_id_t id, size_t* count )
         {
             count[0]+=1;
         }, &count );

--- a/unit_test/check_entity_one_alloc.cpp
+++ b/unit_test/check_entity_one_alloc.cpp
@@ -3,6 +3,7 @@
 #include <atomic>
 #include <chrono>
 #include <set>
+#include <cmath>
 
 ztech::ecs::entity_array global_entities;
 
@@ -56,7 +57,7 @@ int main( int argc, char* argv[] )
         printf( "Trying to for_each parallel\n" );
         std::atomic< size_t > count = 0;
         auto start = std::chrono::steady_clock::now( );
-        global_entities.for_each_parallel< 2 >( [&count, &start]( ztech::ecs::entity_id_t _id )
+        global_entities.for_each_parallel< 2 >( [&count, &start]( ztech::ecs::entity_id_t _id, std::size_t thread_index )
         {
             using namespace std::chrono_literals;
             ++count;
@@ -91,7 +92,7 @@ int main( int argc, char* argv[] )
         printf( "Trying to for_each parallel\n" );
         std::atomic< size_t > count = 0;
         auto start = std::chrono::steady_clock::now( );
-        global_entities.for_each_parallel< 2 >( [&count, &start]( ztech::ecs::entity_id_t _id )
+        global_entities.for_each_parallel< 2 >( [&count, &start]( ztech::ecs::entity_id_t _id, std::size_t thread_index )
         {
             using namespace std::chrono_literals;
             ++count;
@@ -101,6 +102,39 @@ int main( int argc, char* argv[] )
         auto dur = std::chrono::duration_cast< std::chrono::milliseconds >( end - start );
         printf( "Time: %zu, Count: %zu\n", dur.count( ), count.load( ) );
         if ( count != 1 ) return 7;
+    }
+
+    {
+        constexpr size_t new_entity_count = 100000;
+        std::array< double, new_entity_count + 1 > results;
+        std::vector< ztech::ecs::entity_id_t > ids;
+        global_entities.alloc( ids, new_entity_count );
+        std::atomic< size_t > count = 0;
+        auto onecore_start = std::chrono::steady_clock::now( );
+        global_entities.for_each( [&count, &results]( ztech::ecs::entity_id_t _id )
+        {
+            ++count;
+            auto i = sqrt( double( _id ) );
+            results[ _id ] = pow( i, _id );
+        });
+        auto onecore_end = std::chrono::steady_clock::now( );
+        auto onecore_dur = std::chrono::duration_cast< std::chrono::microseconds >( onecore_end - onecore_start );
+        printf( "OneThread: Time: %zu, Count: %zu\n", onecore_dur.count( ), count.load( ) );
+        if ( count != new_entity_count + 1 ) return 8;
+
+        auto twocore_start = std::chrono::steady_clock::now( );
+        count = 0;
+        global_entities.for_each_parallel< 8 >( [&count, &results]( ztech::ecs::entity_id_t _id, std::size_t thread_index )
+        {
+            ++count;
+            auto i = sqrt( double(_id) );
+            results[ _id ] = pow( i, _id );
+        });
+        auto twocore_end = std::chrono::steady_clock::now( );
+        auto twocore_dur = std::chrono::duration_cast< std::chrono::microseconds >( twocore_end - twocore_start );
+        printf( "TwoThread: Time: %zu, Count: %zu\n", twocore_dur.count( ), count.load( ) );
+        if ( count != new_entity_count + 1 ) return 8;
+        if ( twocore_dur > ( onecore_dur * 1.5 ) ) return 8;
     }
 
     printf( "Success\n" );


### PR DESCRIPTION
CPP17 Feature switch
for_each_parallel use the c++17 feature or using the basic for_each
old for_each_parallel method deprecated

( branch name is wrong )
Feature tested with g++ 9.3.0